### PR TITLE
Iterator for key added

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ export default function index() {
       <div className="flex flex-wrap justify-start">
         {animals.map((animal, index) => {
           return (
-            <div className="w-1/2 md:w-1/3 lg:w-1/4 p-2">
+            <div key={index} className="w-1/2 md:w-1/3 lg:w-1/4 p-2">
               <div className="px-4 py-2 bg-white rounded-lg shadow-md overflow-hidden">
                 <Card
                   picture_adress={animal.picture_adress}


### PR DESCRIPTION
ビルド（デプロイ）の際にのみ実行されるEslintエラーが存在したため、予定通りの公開ができていません。
jsxをMapで展開する際のkeyの付け忘れというケアレスミスのため早めにご承認いただけますと幸いです。