### PR TITLE
detailタグsummaryタグを使用してカード初期表示のサイズを固定化

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -11,7 +11,10 @@ export default function Card(props: card) {
         alt="Card Image"
       />
       <h2 className="text-lg font-medium text-gray-900">{name}</h2>
-      <p className="mt-2 text-gray-600">{explanation}</p>
+      <details>
+        <summary>説明</summary>
+        <p className="mt-2 text-gray-600">{explanation}</p>
+      </details>
       <div className="mt-4">
         <a
           href={related_url}


### PR DESCRIPTION
カードをクリックすると子画面が出力されて詳細の確認が可能になる。※スマートフォンの場合は画面いっぱいで良い
→コミットのタイトル通り、元のイッシューの上記の方針をより簡素化させた形でカードコンポーネントの表示を固定化させました。説明をクリックするとテキストが表示されるようになります。
コミットタイトル：detailタグsummaryタグを使用してカード初期表示のサイズを固定化

[https://github.com/kazuto09/CuriousAlbum/issues/3](url)